### PR TITLE
Fix homepage scroll issue by adjusting container styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 
 .home-page-container {
     position: relative;
-    overflow: hidden;
+    overflow-x: hidden;
 }
 
 @supports (height: 100svh) {


### PR DESCRIPTION
Fixed the problem where the homepage was not scrollable on small screen sizes (320x480).
Fixes #5 
